### PR TITLE
Add a missing character to the profile placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There may be circumstances when it is easier/better to set the appropriate envir
 
 Since the script cannot directly set the environment variables in the calling shell process, it is necessary to use the following syntax:
 
-`eval "$(aws2-wrap --profile <awsprofilename --export)"`
+`eval "$(aws2-wrap --profile <awsprofilename> --export)"`
 
 For example:
 


### PR DESCRIPTION
Added a missing `>` to the AWS Profile placeholder in the `README.md` example section.