### PR TITLE
Improve argument handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,11 @@ https://pypi.org/project/aws2-wrap
 
 ## Run a command using AWS SSO credentials
 
-`aws2-wrap --profile <awsprofilename> --exec "<command>"`
-
-Note that you must enclose the command to be executed within double-quotes in order to ensure that any parameters are passed to that sub-command and not to `aws2-wrap`.
+`aws2-wrap [--profile <awsprofilename>] <command>`
 
 For example:
 
-`aws2-wrap --profile MySSOProfile --exec "terraform"`
+`aws2-wrap --profile MySSOProfile terraform plan`
 
 ## Export the credentials
 
@@ -25,7 +23,7 @@ There may be circumstances when it is easier/better to set the appropriate envir
 
 Since the script cannot directly set the environment variables in the calling shell process, it is necessary to use the following syntax:
 
-`eval "$(aws2-wrap --profile <awsprofilename> --export)"`
+`eval "$(aws2-wrap [--profile <awsprofilename>] --export)"`
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ For example:
 
 `aws2-wrap --profile MySSOProfile terraform plan`
 
+Also you can use AWS_PROFILE(AWS_DEFAULT_PROFILE) environment variable:
+
+`AWS_PROFILE=MySSOProfile aws2-wrap terraform plan`
+
 ## Export the credentials
 
 There may be circumstances when it is easier/better to set the appropriate environment variables so that they can be re-used by any `aws` command.

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -25,10 +25,10 @@ from datetime import datetime, timezone
 def process_arguments():
     """ Check and extract arguments provided. """
     parser = argparse.ArgumentParser(allow_abbrev=False)
-    parser.add_argument("--export", action="store")
+    parser.add_argument("--export", action="store_true")
     profile_from_envvar = os.environ.get("AWS_PROFILE", os.environ.get("AWS_DEFAULT_PROFILE", None))
     parser.add_argument("--profile", action="store", default=profile_from_envvar)
-    parser.add_argument("exec", action="store", nargs=argparse.REMAINDER)
+    parser.add_argument("exec", action="store", nargs=argparse.REMAINDER, help="a command what you want to wrap")
     args = parser.parse_args()
     return args
 

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -25,9 +25,8 @@ from datetime import datetime, timezone
 def process_arguments():
     """ Check and extract arguments provided. """
     parser = argparse.ArgumentParser(allow_abbrev=False)
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument("--export", action="store_true")
-    group.add_argument("--exec", action="store")
+    parser.add_argument("--export", action="store")
+    parser.add_argument("exec", action="store", nargs=argparse.REMAINDER)
     profile_from_envvar = os.environ.get("AWS_PROFILE", os.environ.get("AWS_DEFAULT_PROFILE", None))
     parser.add_argument("--profile", action="store", default=profile_from_envvar)
     args = parser.parse_args()
@@ -138,7 +137,7 @@ def main():
         os.environ["AWS_ACCESS_KEY_ID"] = access_key
         os.environ["AWS_SECRET_ACCESS_KEY"] = secret_access_key
         os.environ["AWS_SESSION_TOKEN"] = session_token
-        os.system(args.exec)
+        os.system(" ".join(args.exec))
 
 
 if __name__ == '__main__':

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -26,9 +26,9 @@ def process_arguments():
     """ Check and extract arguments provided. """
     parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--export", action="store")
-    parser.add_argument("exec", action="store", nargs=argparse.REMAINDER)
     profile_from_envvar = os.environ.get("AWS_PROFILE", os.environ.get("AWS_DEFAULT_PROFILE", None))
     parser.add_argument("--profile", action="store", default=profile_from_envvar)
+    parser.add_argument("exec", action="store", nargs=argparse.REMAINDER)
     args = parser.parse_args()
     return args
 

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# aws2-wrap --profile <profile> [--export | --exec <run command>]
+# aws2-wrap [--profile <profile>] [--export | --exec <run command>]
 #
 # A simple script that exports the accessKeyId, secretAccessKey and sessionToken for the specified
 # AWS SSO credentials, or it can run a subprocess with those credentials.
@@ -28,7 +28,8 @@ def process_arguments():
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--export", action="store_true")
     group.add_argument("--exec", action="store")
-    parser.add_argument("--profile", action="store", required=True)
+    profile_from_envvar = os.environ.get("AWS_PROFILE", os.environ.get("AWS_DEFAULT_PROFILE", None))
+    parser.add_argument("--profile", action="store", default=profile_from_envvar)
     args = parser.parse_args()
     return args
 

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -123,6 +123,8 @@ def get_role_credentials(profile_name, sso_role_name, sso_account_id, sso_access
 def main():
     """ Main! """
     args = process_arguments()
+    if args.profile is None:
+        sys.exit("Please specify profile name by --profile or environment variable AWS_PROFILE")
     sso_start_url, sso_region, sso_account_id, sso_role_name = retrieve_profile(args.profile)
     sso_access_token = retrieve_token(sso_start_url, sso_region, args.profile)
     access_key, secret_access_key, session_token = get_role_credentials(

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# aws2-wrap [--profile <profile>] [--export | --exec <run command>]
+# aws2-wrap [-h] [--export] [--profile PROFILE] <command>
 #
 # A simple script that exports the accessKeyId, secretAccessKey and sessionToken for the specified
 # AWS SSO credentials, or it can run a subprocess with those credentials.


### PR DESCRIPTION
Main purpose is to remove double-quotes to exec.

# I tested

```sh
$ export AWS_DEFAULT_PROFILE=sandbox
$ ./aws2wrap/__init__.py echo 1
1
```