### PR TITLE
Fix output type different than JSON

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -101,7 +101,8 @@ def get_role_credentials(profile_name, sso_role_name, sso_account_id, sso_access
             "--role-name", sso_role_name,
             "--account-id", sso_account_id,
             "--access-token", sso_access_token,
-            "--region", sso_region
+            "--region", sso_region,
+            "--output", "json"
         ],
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE


### PR DESCRIPTION
Fixes `json.decoder.JSONDecodeError` if the default output type is different than json in `~/.aws/config`.