### PR TITLE
support AWS_CONFIG_FILE environment variable

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -45,7 +45,10 @@ def retrieve_attribute(profile, tag):
 
 def retrieve_profile(profile_name):
     """ Find the AWS Config profile matching the specified profile name. """
-    config_path = os.path.abspath(os.path.expanduser("~/.aws/config"))
+    if "AWS_CONFIG_FILE" in os.environ:
+        config_path = os.path.abspath(os.environ.get("AWS_CONFIG_FILE"))
+    else:
+        config_path = os.path.abspath(os.path.expanduser("~/.aws/config"))
     config = configparser.ConfigParser()
     config.read(config_path)
     # Look for the required profile


### PR DESCRIPTION
AWS configuration file can also be placed in custom locations.

This MR adds support for reading `AWS_CONFIG_FILE` environment variable that is used for path specification.

Full list of available environment variables:
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html