### PR TITLE
Support using IAM role by source_profile and role_arn attributes

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -51,11 +51,17 @@ def retrieve_profile(profile_name):
         config_path = os.path.abspath(os.path.expanduser("~/.aws/config"))
     config = configparser.ConfigParser()
     config.read(config_path)
+    
+    if profile_name == "default":
+        section_name = "default"
+    else:
+        section_name = "profile %s" % profile_name
+
     # Look for the required profile
-    if "profile %s" % profile_name not in config:
+    if section_name not in config:
         sys.exit("Cannot find profile '%s' in ~/.aws/config" % profile_name)
     # Retrieve the values as dict
-    profile = dict(config["profile %s" % profile_name])
+    profile = dict(config[section_name])
 
     # append profile_name as an attribute
     profile["profile_name"] = profile_name

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -211,6 +211,9 @@ def main():
         print("export AWS_ACCESS_KEY_ID=\"%s\"" % access_key)
         print("export AWS_SECRET_ACCESS_KEY=\"%s\"" % secret_access_key)
         print("export AWS_SESSION_TOKEN=\"%s\"" % session_token)
+        # If region is specified in profile, also export AWS_REGION
+        if "region" in profile:
+            print("export AWS_REGION=\"%s\"" % retrieve_attribute(profile, "region"))
     elif args.process:
         output = {
             "Version": 1,
@@ -224,6 +227,9 @@ def main():
         os.environ["AWS_ACCESS_KEY_ID"] = access_key
         os.environ["AWS_SECRET_ACCESS_KEY"] = secret_access_key
         os.environ["AWS_SESSION_TOKEN"] = session_token
+        # If region is specified in profile, also set AWS_REGION
+        if "region" in profile:
+            os.environ["AWS_REGION"] = retrieve_attribute(profile, "region")
         if args.exec is not None:
             status = os.system(args.exec)
         elif args.command is not None:


### PR DESCRIPTION
# What is the purpose
Main purpose of this PR is to support [Using an IAM role in the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html) with SSO.

I have the config file using `source_profile` and `role_arn` such as
```
[default]
sso_start_url = xxxxxxxxxxxx
sso_region = us-west-2
sso_account_id = xxxxxxxxxxxx
sso_role_name = SSORoleName

[profile account1]
role_arn = arn:aws:iam::xxxxxxxxxxxx:role/role-to-be-assumed
source_profile = default
region = ap-northeast-1
```

It works when I use AWS CLI.
```
$ aws --profile account1 ec2 describe-instances
{
    "Reservations": [
...
```

But, it dose not work using `aws2-wrap`.
```
$ aws2-wrap --profile account1 aws ec2 describe-instances
'sso_start_url' not in '<Section: profile account1>' profile
```

Supporting this feature would be useful for users who manage AWS accounts by IAM roles.

# What is changed
* enable to handle `source_profile` and `role_arn` attributes by implementing function to do `sts assume-role`
* treat the profile values got from config file as a `dict` value to append additional information such as `source_profile` values
* support `region` attribute in profile
* support `default` profile

# What I tested
`~/.aws/config`:
```
[default]
sso_start_url = xxxxxxxxxxxx
sso_region = us-west-2
sso_account_id = xxxxxxxxxxxx
sso_role_name = SSORoleName

[profile account1]
role_arn = arn:aws:iam::xxxxxxxxxxxx:role/role-to-be-assumed
source_profile = default
region = ap-northeast-1
```

command:
```
$ python3 aws2wrap/__init__.py --profile account1 aws ec2 describe-instances
{
    "Reservations": [
...
```