### PR TITLE
Fix type error of 'expiration' when assuming role and using --process flag

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -138,7 +138,10 @@ def get_role_credentials(profile):
         print(result.stderr.decode(), file=sys.stderr)
         sys.exit("Please login with 'aws sso login --profile=%s'" % profile_name)
 
-    return json.loads(result.stdout)
+    output = json.loads(result.stdout)
+    # convert expiration from float value to isoformat string
+    output["roleCredentials"]["expiration"] = datetime.fromtimestamp(float(output["roleCredentials"]["expiration"])/1000).replace(tzinfo=timezone.utc).isoformat()
+    return output
 
 
 def get_assumed_role_credentials(profile):
@@ -226,7 +229,7 @@ def main():
             "AccessKeyId": access_key,
             "SecretAccessKey": secret_access_key,
             "SessionToken": session_token,
-            "Expiration": datetime.fromtimestamp(float(expiration)/1000).replace(tzinfo=timezone.utc).isoformat()
+            "Expiration": expiration,
         }
         print(json.dumps(output))
     else:


### PR DESCRIPTION
When you use both a feature "Assuming a role via AWS SSO" and --process flag together, the following error occurs because the expiration value returned by `aws sts assume-role` is already string.
```
$ aws2-wrap --profile profile_name --process
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/bin/aws2-wrap", line 8, in <module>
    sys.exit(main())
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/aws2wrap/__init__.py", line 229, in main
    "Expiration": datetime.fromtimestamp(float(expiration)/1000).replace(tzinfo=timezone.utc).isoformat()
ValueError: could not convert string to float: '2020-09-07T04:16:05+00:00'
```

To fix it, I changed `get_role_credentials`  function to return expiration value converted into iso format string.