### PR TITLE
Add support for generating temporary credential and config file profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Examples:
 
 `AWS_PROFILE=MySSOProfile aws2-wrap terraform plan`
 
+## Generate a temporary profile in the $AWS_CONFIG_FILE and $AWS_SHARED_CREDENTIALS_FILE file
+
+There are some utilities which work better with the configuration files rather than the environment variables. For example, if you need to access more than one profile at a time.
+
+`aws2-wrap --generate --profile $AWS_PROFILE --credentialsfile $AWS_SHARED_CREDENTIALS_FILE --configfile $AWS_CONFIG_FILE --outprofile $DESTINATION_PROFILE`
+
 ## Export the credentials
 
 There may be circumstances when it is easier/better to set the appropriate environment variables so that they can be re-used by any `aws` command.

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -33,8 +33,8 @@ def process_arguments():
     profile_from_envvar = os.environ.get("AWS_PROFILE", os.environ.get("AWS_DEFAULT_PROFILE", None))
     parser.add_argument("--profile", action="store", default=profile_from_envvar, help="the source profile to use for creating credentials")
     parser.add_argument("--outprofile", action="store", default="default", help="the destination profile to save generated credentials")
-    parser.add_argument("--configfile", action="store", default="./config", help="the config file to append resulting config")
-    parser.add_argument("--credentialsfile", action="store", default="./credentials", help="the credentials file to append resulting credentials")
+    parser.add_argument("--configfile", action="store", default="~/.aws/config", help="the config file to append resulting config")
+    parser.add_argument("--credentialsfile", action="store", default="~/.aws/credentials", help="the credentials file to append resulting credentials")
     parser.add_argument("command", action="store", nargs=argparse.REMAINDER, help="a command that you want to wrap")
     args = parser.parse_args()
     return args
@@ -232,14 +232,13 @@ def main():
             print("Writing Credentials to %s" % args.credentialsfile)
             print("The credentials will expire at %s" % expiration)
             credentials_file = open(args.credentialsfile, 'a+')
-            credentials_file.write("[%s]\n" % args.outprofile)
+            credentials_file.write("\n[%s]\n" % args.outprofile)
             credentials_file.write("aws_access_key_id = %s\n" % access_key)
             credentials_file.write("aws_secret_access_key = %s\n" % secret_access_key)
-            credentials_file.write("aws_session_token = %s\n" % session_token)
             credentials_file.close()
             print("Writing Configuration to %s" % args.configfile)
             configuration_file = open(args.configfile, 'a+')
-            configuration_file.write("[%s]\n" % args.outprofile)
+            configuration_file.write("\n[%s]\n" % args.outprofile)
             if "region" in profile:
                 configuration_file.write("region = %s\n" % retrieve_attribute(profile, "region"))
     elif args.process:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="aws2-wrap",
-    version="1.1.1",
+    version="1.1.2",
     description="A wrapper for executing a command with AWS CLI v2 and SSO",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I needed to output AWS SSO temporary credentials to multiple profiles in order to use a Terraform installation with remote state in multiple AWS acocunts.