### PR TITLE
Fix: use AWS_DEFAULT_REGION instead of AWS_REGION

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -220,9 +220,9 @@ def main():
         print("export AWS_ACCESS_KEY_ID=\"%s\"" % access_key)
         print("export AWS_SECRET_ACCESS_KEY=\"%s\"" % secret_access_key)
         print("export AWS_SESSION_TOKEN=\"%s\"" % session_token)
-        # If region is specified in profile, also export AWS_REGION
-        if "region" in profile:
-            print("export AWS_REGION=\"%s\"" % retrieve_attribute(profile, "region"))
+        # If region is specified in profile, also export AWS_DEFAULT_REGION
+        if "AWS_DEFAULT_REGION" not in os.environ and "region" in profile:
+            print("export AWS_DEFAULT_REGION=\"%s\"" % retrieve_attribute(profile, "region"))
     elif args.process:
         output = {
             "Version": 1,
@@ -236,9 +236,9 @@ def main():
         os.environ["AWS_ACCESS_KEY_ID"] = access_key
         os.environ["AWS_SECRET_ACCESS_KEY"] = secret_access_key
         os.environ["AWS_SESSION_TOKEN"] = session_token
-        # If region is specified in profile, also set AWS_REGION
-        if "region" in profile:
-            os.environ["AWS_REGION"] = retrieve_attribute(profile, "region")
+        # If region is specified in profile, also set AWS_DEFAULT_REGION
+        if "AWS_DEFAULT_REGION" not in os.environ and "region" in profile:
+            os.environ["AWS_DEFAULT_REGION"] = retrieve_attribute(profile, "region")
         if args.exec is not None:
             status = os.system(args.exec)
         elif args.command is not None:


### PR DESCRIPTION
Now, `AWS_REGION` environment variable is used to set region for request.
However, `AWS_DEFAULT_REGION` is preferred because `AWS_REGION` is not listed in [Environment variables to configure the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).

I also fixed a condition to set value, because it overrides profile setting as shown below.

> If defined, this environment variable overrides the value for the profile setting region.