### PR TITLE
Fix configfile

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -222,6 +222,7 @@ def process_cred_generation(
     with open(credentialsfile, "w") as file:
         config.write(file)
 
+    config = configparser.ConfigParser()
     config.read(configfile)
     new_config = {}
     if "region" in profile:


### PR DESCRIPTION
The config isn't reset between writing credentialsfile and configfile, which leads to existing credentials being written to the configfile. This PR instantiates a new ConfigParser after writing credentialsfile.