### PR TITLE
Call expanduser on default arguments

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -212,6 +212,9 @@ def process_cred_generation(
     access_key, secret_access_key, session_token, profile):
     """ Export the credentials and config """
 
+    credentialsfile = os.path.expanduser(credentialsfile) 
+    configfile = os.path.expanduser(configfile) 
+
     config = configparser.ConfigParser()
     config.read(credentialsfile)
     config[outprofile] = {


### PR DESCRIPTION
The default arguments for `--configfile` and `--credentialsfile` contain the tilde symbol, which needs to be expanded. Otherwise Python can't read/write these with the default values.