### PR TITLE
Fix Incorrect Parsing of Epoch Timestamp

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -149,7 +149,7 @@ def get_role_credentials(profile):
 
     output = json.loads(result.stdout)
     # convert expiration from float value to isoformat string
-    output["roleCredentials"]["expiration"] = datetime.fromtimestamp(float(output["roleCredentials"]["expiration"])/1000).replace(tzinfo=timezone.utc).isoformat()
+    output["roleCredentials"]["expiration"] = datetime.fromtimestamp(float(output["roleCredentials"]["expiration"])/1000, tz=timezone.utc).isoformat()
     return output
 
 


### PR DESCRIPTION
Epoch timestamp returned by the get_role_credentials method was
incorrectly parsed. The timestamp was read into local time, then the
local datetime object was interpreted as UTC.

For example, in GMT-7, a timestamp would be correctly interpreted in
local time, for example, "2021-03-11 12:00:00.000." Then, this time
would simply be cast to UTC without actually changing the hour, in this
case "2021-03-11 12:00:00.000Z."

This was undesired behavior, as short-lived session tokens were rendered
completely unusable if the time difference from UTC was sufficiently
large.

This commit introduces a fix that correctly parses the timestamp in UTC.
