### PR TITLE
Fix bug AWS SDK Java TZ

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -323,7 +323,7 @@ def main():
             "AccessKeyId": access_key,
             "SecretAccessKey": secret_access_key,
             "SessionToken": session_token,
-            "Expiration": expiration,
+            "Expiration": expiration.replace('+00:00', 'Z'),
         }
         print(json.dumps(output))
     else:

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ with open("README.md", "r") as fh:
 
 setup(
     name="aws2-wrap",
-    version="1.1.9",
+    version="1.1.10",
     description="A wrapper for executing a command with AWS CLI v2 and SSO",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/linaro-its/aws2-wrap",
+    url="https://github.com/life360/aws2-wrap",
     author="Philip Colmer",
     author_email="it-support@linaro.org",
     classifiers=[


### PR DESCRIPTION
AWS SDK Java Expects Expiration in the credentials_process to have the timezone specified as Z, not +00:00.