### PR TITLE
Change error string if aws config path is changed

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -63,7 +63,7 @@ def retrieve_profile(profile_name):
 
     # Look for the required profile
     if section_name not in config:
-        sys.exit("Cannot find profile '%s' in ~/.aws/config" % profile_name)
+        sys.exit("Cannot find profile '%s' in %s" % (profile_name, config_path))
     # Retrieve the values as dict
     profile = dict(config[section_name])
 


### PR DESCRIPTION
The code respects AWS_CONFIG_FILE but the error message for missing profile doesn't show that.

This also makes the error message for the default config file show the file with its absolute path, which seems fine to me but I wanted to call out as a change in behavior.

Before:
```
LMASSA-MAC:aws2wrap luke$ python3 __init__.py --profile default
LMASSA-MAC:aws2wrap luke$ python3 __init__.py --profile nonexistentprofile
Cannot find profile 'nonexistentprofile' in ~/.aws/config
LMASSA-MAC:aws2wrap luke$ AWS_CONFIG_FILE=/path/to/non/existent/file python3 __init__.py --profile default
Cannot find profile 'default' in ~/.aws/config
```

After:
```
LMASSA-MAC:aws2wrap luke$ python3 __init__.py --profile default
LMASSA-MAC:aws2wrap luke$ python3 __init__.py --profile nonexistentprofile
Cannot find profile 'nonexistentprofile' in /Users/luke/.aws/config
LMASSA-MAC:aws2wrap luke$ AWS_CONFIG_FILE=/path/to/non/existent/file python3 __init__.py --profile default
Cannot find profile 'default' in /path/to/non/existent/file
```