### PR TITLE
Improve error handling.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.6', '3.7', '3.8', '3.9' ]
-    name: Python ${{ matrix.python-version }} sample
+    name: CI Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/aws2wrap/test/test_aws2wrap.py
+++ b/aws2wrap/test/test_aws2wrap.py
@@ -1,29 +1,29 @@
 """Unittests for aws2wrap."""
-
-
 import unittest
-from unittest import mock
 
 import aws2wrap
 
 # pylint: disable=missing-class-docstring,missing-function-docstring
 
 
-class FakeSysExit(Exception):
-    """Fake Exception for sys.exit calls."""
+class TestProcessArguments(unittest.TestCase):
+    """Test a few cases of the cli parsing to ensure it is functional."""
+
+    def test_no_args(self):
+        args = aws2wrap.process_arguments(['aws2-wrap'])
+        self.assertFalse(args.export)
+        self.assertFalse(args.generate)
+
+    def test_exclusive(self):
+        with self.assertRaises(SystemExit):
+            aws2wrap.process_arguments(['aws2-wrap', '--export', '--generate'])
 
 
 class TestRetrieveAttribute(unittest.TestCase):
-    def setUp(self) -> None:
-        self.addCleanup(mock.patch.stopall)
-        self.exit = mock.patch('sys.exit').start()
-        self.exit.side_effect = FakeSysExit()
 
     def test_success(self):
         self.assertEqual(42, aws2wrap.retrieve_attribute({'answer': 42}, 'answer'))
-        self.exit.assert_not_called()
 
     def test_failure(self):
-        with self.assertRaises(FakeSysExit):
+        with self.assertRaises(aws2wrap.Aws2WrapError):
             aws2wrap.retrieve_attribute({'answer': 42}, 'question')
-            self.exit.assert_called_once_with()


### PR DESCRIPTION
* Added custom Aws2WrapError class.
* Use single sys.exit() so code can be more easily used as a library and more easily unittested.
* Use f-strings for the errors (faster and more readable than the legacy % strings).
* Renamed checks to be 'CI Python 3.6', 3.7, 3.8, 3.9.
* Add support to parse the command line options without parsing sys.argv(): can be used as a library.