### PR TITLE
v1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ and `<command>` will be run under `role-to-be-assumed`.
 
 ## Contributing
 
-Contributions are more than welcome, particularly if you are able to expand on the test code. Please ensure, though, that before you submit a Pull Request, you run `make test` to ensure that your changes don't break any of the existing tests.
+Contributions are more than welcome, particularly if you are able to expand on the test code. Please ensure, though, that before you submit a Pull Request, you run `make test` to ensure that your changes don't break any of the existing tests and `make pylint` to ensure that the linter is happy. Please note that the CI/CD pylint test *may* use different pylint rules from your own local setup.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please note that the script is called `aws2-wrap` to show that it works with AWS
 
 <https://pypi.org/project/aws2-wrap>
 
-`pip3 install aws2-wrap==1.2.3`
+`pip3 install aws2-wrap==1.2.4`
 
 ## Run a command using AWS SSO credentials
 
@@ -106,6 +106,10 @@ allowing you to then run:
 `aws2-wrap --profile account1 <command>`
 
 and `<command>` will be run under `role-to-be-assumed`.
+
+## Contributing
+
+Contributions are more than welcome, particularly if you are able to expand on the test code. Please ensure, though, that before you submit a Pull Request, you run `make test` to ensure that your changes don't break any of the existing tests.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ There are some utilities which work better with the configuration files rather t
 
 `aws2-wrap --generate --profile $AWS_PROFILE --credentialsfile $AWS_SHARED_CREDENTIALS_FILE --configfile $AWS_CONFIG_FILE --outprofile $DESTINATION_PROFILE`
 
+Optionally, you can specify `--generatestdout` instead of providing `--credentialsfile`, `--configfile` and `--outprofile`, and the generated credentials will then be output to the console.
+
 ## Export the AWS SSO credentials
 
 There may be circumstances when it is easier/better to set the appropriate environment variables so that they can be re-used by any `aws` command.

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -49,7 +49,9 @@ def process_arguments(argv: List[str]) -> argparse.Namespace:
     group.add_argument(
         "--export", action="store_true", help="export credentials as environment variables")
     group.add_argument(
-        "--generate", action="store_true", help="generate credentials file from the input profile")
+        "--generate",
+        action="store_true",
+        help="generate credentials from the input profile, optionally stored in specified file")
     group.add_argument("--process", action="store_true")
     group.add_argument("--exec", action="store")
     profile_from_envvar = os.environ.get(
@@ -58,6 +60,9 @@ def process_arguments(argv: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--profile", action="store", default=profile_from_envvar,
         help="the source profile to use for creating credentials")
+    parser.add_argument(
+        "--generatestdout", action="store_true",
+        help="outputs generated credentials to the console not saved to file")
     parser.add_argument(
         "--outprofile", action="store", default="default",
         help="the destination profile to save generated credentials")
@@ -85,7 +90,7 @@ def retrieve_attribute(profile: Dict[str, Any], tag: str) -> Any:
         Aws2WrapError: The tag was not present in the profile.
     """
     if tag not in profile:
-        raise Aws2WrapError(f"{tag!r} not in {profile!r} profile")
+        raise Aws2WrapError(f"{tag!r} not found in profile: {profile!r}")
     return profile[tag]
 
 
@@ -364,7 +369,7 @@ def process_cred_generation(  # pylint: disable=too-many-arguments
         new_config = {
             "region": retrieve_attribute(profile, "region")
         }
-    config[outprofile] = new_config
+    config["profile %s" % outprofile] = new_config
     with open(configfile, mode="w", encoding="utf-8") as file:
         config.write(file)
 
@@ -451,10 +456,6 @@ def main(argv: Optional[List[str]]=None) -> int:
         argv = sys.argv
     args = process_arguments(argv)
     try:
-        if args.profile is None:
-            raise Aws2WrapError(
-                "Please specify profile name by --profile or environment variable AWS_PROFILE")
-
         profile = retrieve_profile(args.profile)
 
         if "source_profile" in profile:
@@ -471,7 +472,11 @@ def main(argv: Optional[List[str]]=None) -> int:
             # On Windows, parent process is aws2-wrap.exe, in unix it's the shell
             export_credentials(access_key, secret_access_key, session_token, profile)
         elif args.generate:
-            if args.outprofile is not None:
+            if args.generatestdout or args.outprofile is None:
+                print("aws_access_key_id =", access_key)
+                print("aws_secret_access_key =", secret_access_key)
+                print("aws_session_token =", session_token)
+            else:
                 process_cred_generation(
                     args.credentialsfile, args.configfile, expiration, args.outprofile,
                     access_key, secret_access_key, session_token, profile)

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -369,7 +369,7 @@ def process_cred_generation(  # pylint: disable=too-many-arguments
         new_config = {
             "region": retrieve_attribute(profile, "region")
         }
-    config["profile %s" % outprofile] = new_config
+    config[f"profile {outprofile}"] = new_config
     with open(configfile, mode="w", encoding="utf-8") as file:
         config.write(file)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="aws2-wrap",
-    version="1.2.3",
+    version="1.2.4",
     description="A wrapper for executing a command with AWS CLI v2 and SSO",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Adds a new `--generatestdout` command-line option to allow generated credentials to be displayed on the console rather than saved to file. Implements #51 
