### PR TITLE
Fix profile headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please note that the script is called `aws2-wrap` to show that it works with AWS
 
 <https://pypi.org/project/aws2-wrap>
 
-`pip3 install aws2-wrap==1.2.6`
+`pip3 install aws2-wrap==1.2.7`
 
 ## Run a command using AWS SSO credentials
 

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -370,7 +370,10 @@ def process_cred_generation(  # pylint: disable=too-many-arguments
         new_config = {
             "region": retrieve_attribute(profile, "region")
         }
-    config[f"profile {outprofile}"] = new_config
+    if outprofile == "default":
+        config["default"] = new_config
+    else:
+        config[f"profile {outprofile}"] = new_config
     with open(configfile, mode="w", encoding="utf-8") as file:
         config.write(file)
 
@@ -473,7 +476,7 @@ def main(argv: Optional[List[str]]=None) -> int:
             # On Windows, parent process is aws2-wrap.exe, in unix it's the shell
             export_credentials(access_key, secret_access_key, session_token, profile)
         elif args.generatestdout:
-            print(f"[profile {args.outprofile}]")
+            print(f"[{args.outprofile}]")
             print("aws_access_key_id =", access_key)
             print("aws_secret_access_key =", secret_access_key)
             print("aws_session_token =", session_token)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="aws2-wrap",
-    version="1.2.6",
+    version="1.2.7",
     description="A wrapper for executing a command with AWS CLI v2 and SSO",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
For `--generatestdout` don't prefix the profile name with "profile".

If the profile is "default", don't prefix it with "profile" when outputting to the config.
