### PR TITLE
Add no-cli-auto-prompt flag to subprocess

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -3,7 +3,8 @@
 # Copyright (c) 2022 Linaro Ltd
 #
 
-"""Simple AWS Credentials wrapper.
+"""
+Simple AWS Credentials wrapper.
 
 A simple script that exports the accessKeyId, secretAccessKey and sessionToken
 for the specified AWS SSO credentials, or it can run a subprocess with those

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright (c) 2021 Linaro Ltd
+# Copyright (c) 2022 Linaro Ltd
 #
 
 """Simple AWS Credentials wrapper.

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -247,7 +247,8 @@ def get_role_credentials(profile: ProfileDef) -> Dict[str, Any]:
                 "--account-id", sso_account_id,
                 "--access-token", sso_access_token,
                 "--region", sso_region,
-                "--output", "json"
+                "--output", "json",
+                "--no-cli-auto-prompt"
             ],
             check=True,
             stderr=subprocess.PIPE,
@@ -307,7 +308,8 @@ def get_assumed_role_credentials(profile: ProfileDef) -> Dict[str, Dict[str, str
                 "aws", "sts", "assume-role",
                 "--role-arn", retrieve_attribute(profile, "role_arn"),
                 "--role-session-name", role_session_name,
-                "--output", "json"
+                "--output", "json",
+                "--no-cli-auto-prompt"
             ],
             check=True,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
## Background
Using an AWS profile with shared config file setting `cli_auto_prompt = on`, or having the environment variable `AWS_CLI_AUTO_PROMPT=on` will cause the `aws2-wrap` command to fail. 

See documentation on [AWS CLI prompt](https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-parameters-prompting.html).

## Root cause
The `aws` commands that are called from `subprocess.run` do not specify any `cli-auto-prompt` flags, which means that the profile setting/environment variable will decide whether CLI prompting will apply or not. The Python code assumes the result of `subprocess.run` to be a non-interactive json response. Hence the code will hang with CLI prompting enabled.

## Solution
Add the [--no-cli-auto-prompt](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-options.html#cli-configure-options-no-cli-auto-prompt) flag in the `subprocess.run` `aws` calls to disable CLI prompting.