### PR TITLE
Added option to generate only credentials and not config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,19 @@ The script provides the following capabilities:
 * Exporting the AWS SSO credentials
 * Use the credentials via .aws/config
 * Assume a role via AWS SSO
+* Checks if aws sso session is expired, if yes, opens `aws sso login` and automates entering username and password
+* If aws sso session is active then refreshes the token, so it gets extended
 
 Please note that the script is called `aws2-wrap` to show that it works with AWS CLI v2, even though the CLI tool is no longer called `aws2`.
+
+## Prerequisites
+
+Install chromedriver
+1. Downloads specific chromedriver depending on current chrome version installed from https://chromedriver.chromium.org/downloads
+2. Extract and add to PATH
+3. Add to ~/.zshrc for MAC (or ~/.bashrc in Linux) - `export PATH=$PATH:/path/to/chromedriver`
+
+Set env vars - `AWS_SSO_USERNAME` and `AWS_SSO_PASSWORD` to your aws sso username and password
 
 ## Install using `pip`
 
@@ -37,6 +48,10 @@ Examples:
 `AWS_PROFILE=MySSOProfile aws2-wrap terraform plan`
 
 If you are having problems with the use of quotes in the command, you may find one of the other methods works better for you.
+
+## Refresh credentials in $AWS_SHARED_CREDENTIALS_FILE without touching the $AWS_CONFIG_FILE
+
+`aws2-wrap --generate_cred --credentialsfile $AWS_SHARED_CREDENTIALS_FILE`
 
 ## Generate a temporary profile in the $AWS_CONFIG_FILE and $AWS_SHARED_CREDENTIALS_FILE file
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ Please note that the script is called `aws2-wrap` to show that it works with AWS
 
 ## Prerequisites
 
-Install chromedriver
-1. Downloads specific chromedriver depending on current chrome version installed from https://chromedriver.chromium.org/downloads
-2. Extract and add to PATH
-3. Add to ~/.zshrc for MAC (or ~/.bashrc in Linux) - `export PATH=$PATH:/path/to/chromedriver`
+1. Install chromedriver
+	1. Downloads specific chromedriver depending on current chrome version installed from https://chromedriver.chromium.org/downloads
+	2. Extract and add to PATH
+	3. Add to ~/.zshrc for MAC (or ~/.bashrc in Linux) - `export PATH=$PATH:/path/to/chromedriver`
 
-Set env vars - `AWS_SSO_USERNAME` and `AWS_SSO_PASSWORD` to your aws sso username and password
+2. Set env vars - `AWS_SSO_USERNAME` and `AWS_SSO_PASSWORD` to your aws sso username and password as -
+	`export AWS_SSO_USERNAME=xyz; export AWS_SSO_PASSWORD=xyz`
 
 ## Install using `pip`
 

--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -53,6 +53,10 @@ def process_arguments(argv: List[str]) -> argparse.Namespace:
         "--generate",
         action="store_true",
         help="generate credentials from the input profile")
+    group.add_argument(
+        "--generate_cred",
+        action="store_true",
+        help="generate credentials from the input profile, but do not generate config")
     parser.add_argument(
         "--generatestdout",
         action="store_true",
@@ -365,23 +369,24 @@ def process_cred_generation(  # pylint: disable=too-many-arguments
     }
     with open(credentialsfile, mode="w", encoding="utf-8") as file:
         config.write(file)
-
-    config = configparser.ConfigParser()
-    config.read(configfile)
-    new_config = {}
-    if "region" in profile:
-        new_config = {
-            "region": retrieve_attribute(profile, "region")
-        }
-    if outprofile == "default":
-        config["default"] = new_config
-    else:
-        config[f"profile {outprofile}"] = new_config
-    with open(configfile, mode="w", encoding="utf-8") as file:
-        config.write(file)
-
     print(f"Credentials written to {credentialsfile}")
-    print(f"Configuration written to {configfile}")
+
+    if configfile:
+        config = configparser.ConfigParser()
+        config.read(configfile)
+        new_config = {}
+        if "region" in profile:
+            new_config = {
+                "region": retrieve_attribute(profile, "region")
+            }
+        if outprofile == "default":
+            config["default"] = new_config
+        else:
+            config[f"profile {outprofile}"] = new_config
+        with open(configfile, mode="w", encoding="utf-8") as file:
+            config.write(file)
+        print(f"Configuration written to {configfile}")
+
     print(f"The credentials will expire at {expiration}")
 
 
@@ -486,6 +491,10 @@ def main(argv: Optional[List[str]]=None) -> int:
         elif args.generate:
             process_cred_generation(
                 args.credentialsfile, args.configfile, expiration, args.outprofile,
+                access_key, secret_access_key, session_token, profile)
+        elif args.generate_cred:
+            process_cred_generation(
+                args.credentialsfile, "", expiration, args.outprofile,
                 access_key, secret_access_key, session_token, profile)
         elif args.process:
             output = {


### PR DESCRIPTION
I found that everytime I run `aws2-wrap --generate` .aws/config file is also written every-time and when sets region and removes other params like sso-url etc.
So I added an option `aws2-wrap --generate_cred` that generates only credentials file and does not write into .aws/config