### PR TITLE
Add --version flag

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Optional, Union, Tuple  # pylint: disable=wr
 
 import psutil
 
+from aws2wrap.version import __version__
 
 ProfileDef = Dict[str, Union[str, Dict[str, Any]]]
 
@@ -48,7 +49,9 @@ def process_arguments(argv: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(allow_abbrev=False)
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
-        "--export", action="store_true", help="export credentials as environment variables")
+        "--export",
+        action="store_true",
+        help="export credentials as environment variables")
     group.add_argument(
         "--generate",
         action="store_true",
@@ -75,7 +78,12 @@ def process_arguments(argv: List[str]) -> argparse.Namespace:
         "--credentialsfile", action="store", default="~/.aws/credentials",
         help="the credentials file to append resulting credentials")
     parser.add_argument(
-        "command", action="store", nargs=argparse.REMAINDER, help="a command that you want to wrap")
+        "command", action="store", nargs=argparse.REMAINDER,
+        help="a command that you want to wrap")
+    parser.add_argument(
+        "--version", "-v", action="version",
+        version='%(prog)s {version}'.format(version=__version__),
+        help="get version")
     args = parser.parse_args(argv[1:])
     return args
 

--- a/aws2wrap/version.py
+++ b/aws2wrap/version.py
@@ -1,0 +1,2 @@
+# pylint: disable=missing-module-docstring
+__version__ = '1.2.8'

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,32 @@
 """Setup script for aws2wrap."""
 
 from setuptools import setup
+import os
+import re
+
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
+
+
+def get_version():
+    init = open(
+        os.path.join(
+            HERE,
+            "aws2wrap",
+            "version.py"
+        )
+    ).read()
+    return VERSION_RE.search(init).group(1)
+
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+
 setup(
     name="aws2-wrap",
-    version="1.2.8",
+    version=get_version(),
     description="A wrapper for executing a command with AWS CLI v2 and SSO",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## what
- Add --version flag

## why
- Nice to know the current version

## references
- Closes https://github.com/linaro-its/aws2-wrap/issues/57
- Inspiration from https://github.com/salesforce/policy_sentry
- https://stackoverflow.com/a/15406624/2965993

```
✗ aws2-wrap --help
usage: aws2-wrap [-h] [--export] [--generate] [--generatestdout] [--process] [--exec EXEC] [--profile PROFILE] [--outprofile OUTPROFILE]
                 [--configfile CONFIGFILE] [--credentialsfile CREDENTIALSFILE] [--version]
                 ...

positional arguments:
  command               a command that you want to wrap

options:

...snip...

  --version, -v         get version
```

```
✗ aws2-wrap -v
aws2-wrap 1.2.8
✗ aws2-wrap --version
aws2-wrap 1.2.8
```