### PR TITLE
Set config "profile" prefix as optional

### DIFF
--- a/aws2wrap/__init__.py
+++ b/aws2wrap/__init__.py
@@ -136,13 +136,12 @@ def retrieve_profile(profile_name: str) -> ProfileDef:
     """
     config, config_path = read_aws_config()
 
-    if profile_name == "default":
-        section_name = "default"
-    else:
-        section_name = f"profile {profile_name}"
-
     # Look for the required profile
-    if section_name not in config:
+    if f"profile {profile_name}" in config:
+        section_name = f"profile {profile_name}"
+    elif profile_name in config:
+        section_name = profile_name
+    else:
         raise Aws2WrapError(f"Cannot find profile {profile_name!r} in {config_path}")
     # Retrieve the values as dict
     profile: ProfileDef = dict(config[section_name])


### PR DESCRIPTION
## what
- Set config "profile" prefix as optional

## why
- AWS allows `profile` prefix and without that prefix

## references
- Closes https://github.com/linaro-its/aws2-wrap/issues/55
- https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
- Previous PR https://github.com/linaro-its/aws2-wrap/pull/53

```
✗ echo '[profile default]' > ~/.aws/config
✗ aws2-wrap
'sso_start_url' not found in profile: {'profile_name': 'default'}
```

```
✗ echo '[default]' > ~/.aws/config
✗ aws2-wrap
'sso_start_url' not found in profile: {'profile_name': 'default'}
```
